### PR TITLE
Add prettier formatting

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,8 @@
 {
   "parser"  : "babel-eslint",
   "plugins": [
-    "import"
+    "import",
+    "prettier"
   ],
   "extends" : ["airbnb"],
   "rules": {
@@ -12,6 +13,8 @@
     "no-floating-decimal": 0, // .5 is just fine.
     "no-shadow": 2, // Shadowing is a nice language feature, but it can kick
     // eslint-plugin-import
+    "arrow-parens": ["error", "as-needed"], // Conflicts prettier.
+    "space-before-function-paren": ["error", "never"], // Conflicts prettier.
     "import/no-unresolved": [2, {"commonjs": true}],
     "import/named": 2,
     "import/default": 2,
@@ -23,7 +26,10 @@
     "no-use-before-define": 0, // Enable to define styles after using them in component.
     "react/jsx-no-bind": 0, // Enable arrow functions in Props definitions.
     "react/prefer-stateless-function": 0, // Enable functions with state.
-    "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }]
+    "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
+    "prettier/prettier": ["error", {
+        "singleQuote":  true // Still, it's more common to use single quotes.
+    }]
   },
   "globals": {
     "test": false,

--- a/package.json
+++ b/package.json
@@ -37,8 +37,10 @@
     "eslint-config-airbnb": "^14.0.0",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^3.0.2",
+    "eslint-plugin-prettier": "^2.1.1",
     "eslint-plugin-react": "^6.9.0",
     "jest": "^18.1.0",
+    "prettier": "^1.3.1",
     "react-addons-test-utils": "^15.4.2"
   },
   "dependencies": {

--- a/src/server/apps/disableSourceMaps.js
+++ b/src/server/apps/disableSourceMaps.js
@@ -11,7 +11,11 @@ app.use('/*.map', (req, res, next) => {
 });
 
 app.on('mount', () => {
-  console.log('Disable Source Maps %s*.map %s', app.mountpath, process.env.APP_ENV === 'production' ? 'enabled' : 'disabled');
+  console.log(
+    'Disable Source Maps %s*.map %s',
+    app.mountpath,
+    process.env.APP_ENV === 'production' ? 'enabled' : 'disabled'
+  );
 });
 
 export default app;

--- a/src/server/apps/robots.js
+++ b/src/server/apps/robots.js
@@ -3,14 +3,20 @@ import express from 'express';
 const app = express();
 
 app.use('/robots.txt', (req, res) => {
-  res.send([
-    'User-agent: *',
-    process.env.ENABLE_SEARCH_BOTS ? 'Disallow:' : 'Disallow: /'
-  ].join('\n'));
+  res.send(
+    [
+      'User-agent: *',
+      process.env.ENABLE_SEARCH_BOTS ? 'Disallow:' : 'Disallow: /'
+    ].join('\n')
+  );
 });
 
 app.on('mount', () => {
-  console.log('Robots.txt is available at %srobots.txt and %s search bots', app.mountpath, process.env.ENABLE_SEARCH_BOTS ? 'enable' : 'disable');
+  console.log(
+    'Robots.txt is available at %srobots.txt and %s search bots',
+    app.mountpath,
+    process.env.ENABLE_SEARCH_BOTS ? 'enable' : 'disable'
+  );
 });
 
 export default app;

--- a/src/server/apps/sitemap.js
+++ b/src/server/apps/sitemap.js
@@ -2,9 +2,7 @@ import express from 'express';
 
 const app = express();
 
-const pages = [
-  '/',
-];
+const pages = ['/'];
 
 app.use('/sitemap.xml', (req, res) => {
   res.send(`

--- a/src/server/frontend/Html.react.js
+++ b/src/server/frontend/Html.react.js
@@ -2,7 +2,10 @@
 import React, { PropTypes as RPT } from 'react';
 import Rollbar from './scripts/Rollbar';
 import Script from './Script.react';
-import { googleTagManagerNoScript, googleTagManagerScript } from './scripts/GoogleTagManager';
+import {
+  googleTagManagerNoScript,
+  googleTagManagerScript
+} from './scripts/GoogleTagManager';
 
 const Html = ({ bodyHtml, javascripts = {}, helmet, options }) => (
   <html lang="en">
@@ -23,11 +26,20 @@ const Html = ({ bodyHtml, javascripts = {}, helmet, options }) => (
     </head>
     <body>
       {googleTagManagerNoScript()}
-      <script type="text/javascript" dangerouslySetInnerHTML={{ __html: `window.__FEATURES=${JSON.stringify(options.features)}` }} />
+      <script
+        type="text/javascript"
+        dangerouslySetInnerHTML={{
+          __html: `window.__FEATURES=${JSON.stringify(options.features)}`
+        }}
+      />
       <div id="app" dangerouslySetInnerHTML={{ __html: bodyHtml }} />
       <Script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=Symbol" />
-      {!options.disableJS && javascripts.vendor && <Script src={javascripts.vendor} />}
-      {!options.disableJS && javascripts.app && <Script src={javascripts.app} />}
+      {!options.disableJS &&
+        javascripts.vendor &&
+        <Script src={javascripts.vendor} />}
+      {!options.disableJS &&
+        javascripts.app &&
+        <Script src={javascripts.app} />}
     </body>
   </html>
 );

--- a/src/server/frontend/Script.react.js
+++ b/src/server/frontend/Script.react.js
@@ -1,6 +1,6 @@
 import React, { PropTypes as RPT } from 'react';
 
-const Script = ({ src }) => (<script src={src} type="text/javascript" />);
+const Script = ({ src }) => <script src={src} type="text/javascript" />;
 
 Script.propTypes = {
   src: RPT.string.isRequired

--- a/src/server/frontend/__tests__/render.spec.js
+++ b/src/server/frontend/__tests__/render.spec.js
@@ -3,7 +3,9 @@ import Helmet from 'react-helmet';
 import render from '../render';
 
 test('render', () => {
-  global.webpackIsomorphicTools = { assets: () => ({ javascript: { app: 'app.xxx.js' } }) };
+  global.webpackIsomorphicTools = {
+    assets: () => ({ javascript: { app: 'app.xxx.js' } })
+  };
   Helmet.canUseDOM = false;
   expect(render(<div />)).toMatchSnapshot();
 });

--- a/src/server/frontend/index.js
+++ b/src/server/frontend/index.js
@@ -11,7 +11,12 @@ import { getFeatures } from '../../common/featureToggl';
 const app = express();
 const prettyError = new PrettyError();
 
-app.use('/assets', express.static(path.join(__dirname, '..', '..', '..', 'dist', 'public', 'assets')));
+app.use(
+  '/assets',
+  express.static(
+    path.join(__dirname, '..', '..', '..', 'dist', 'public', 'assets')
+  )
+);
 app.use('/', express.static(path.join(__dirname, '..', '..', '..', 'public')));
 
 app.get('*', (req, res, next) => {
@@ -19,7 +24,9 @@ app.get('*', (req, res, next) => {
     if (req.path === '/unknown') {
       return res.status(404).send(render(<NotFound path={req.path} />));
     }
-    return res.status(200).send(render(<App />, { features: getFeatures(req) }));
+    return res
+      .status(200)
+      .send(render(<App />, { features: getFeatures(req) }));
   } catch (err) {
     return next(err);
   }

--- a/src/server/frontend/render.js
+++ b/src/server/frontend/render.js
@@ -5,7 +5,9 @@ import Html from './Html.react';
 import ServerProvider from './ServerProvider.react';
 
 export default function render(app, options = {}) {
-  const appHtml = ReactDOMServer.renderToString(<ServerProvider>{app}</ServerProvider>);
+  const appHtml = ReactDOMServer.renderToString(
+    <ServerProvider>{app}</ServerProvider>
+  );
 
   const { javascript: javascripts } = webpackIsomorphicTools.assets();
 

--- a/src/server/frontend/scripts/GoogleTagManager.js
+++ b/src/server/frontend/scripts/GoogleTagManager.js
@@ -6,7 +6,8 @@ export function googleTagManagerScript() {
 
   return (
     <script
-      dangerouslySetInnerHTML={{ __html: `
+      dangerouslySetInnerHTML={{
+        __html: `
         (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
         new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
         j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
@@ -22,7 +23,8 @@ export function googleTagManagerNoScript() {
 
   return (
     <div
-      dangerouslySetInnerHTML={{ __html: `
+      dangerouslySetInnerHTML={{
+        __html: `
         <!-- Google Tag Manager (noscript) -->
         <script>
           dataLayer= window.dataLayer === 'undefined' ? [] : window.dataLayer;

--- a/src/server/frontend/scripts/Rollbar.js
+++ b/src/server/frontend/scripts/Rollbar.js
@@ -204,10 +204,19 @@ function getRollbarScript() {
   `;
 }
 
-const Rollbar = () => (
-  process.env.ROLLBAR_CLIENT_TOKEN &&
-  process.env.APP_ENV !== 'development' &&
-  <script key="Rollbar" dangerouslySetInnerHTML={{ __html: getRollbarScript(process.env.ROLLBAR_CLIENT_TOKEN, process.env.APP_ENV) }} />) || // eslint-disable-line react/no-danger
+const Rollbar = () =>
+  (process.env.ROLLBAR_CLIENT_TOKEN &&
+    process.env.APP_ENV !== 'development' &&
+    <script
+      key="Rollbar"
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{
+        __html: getRollbarScript(
+          process.env.ROLLBAR_CLIENT_TOKEN,
+          process.env.APP_ENV
+        )
+      }}
+    />) ||
   null;
 
 export default Rollbar;

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -3,7 +3,7 @@ require('../../env');
 
 // Enabling Source maps for node
 require('source-map-support/register');
-require('babel-register');// eslint-disable-line import/no-extraneous-dependencies
+require('babel-register'); // eslint-disable-line import/no-extraneous-dependencies
 
 // Start timer
 const timer = require('../utils/timer');
@@ -31,7 +31,9 @@ const preloadApplication = () => {
     console.log(chalk.green('♥ Application preload finished'));
     return true;
   } catch (error) {
-    console.error(chalk.red('❌  Unable to preload application because of syntax error'));
+    console.error(
+      chalk.red('❌  Unable to preload application because of syntax error')
+    );
     console.log();
     console.error(error);
     return false;
@@ -46,35 +48,43 @@ const watchChanges = () => {
   const sourceFilesRegexp = new RegExp(path.resolve(__dirname, '..'));
 
   // Chokidar is watching for file changes in src directory and ignoring dotfiles and *.json
-  watcher.watch(path.join(__dirname, '..'), { ignored: ignoreRegexp }).on('all', (event, file) => {
-    if (event === 'change') {
-      if (isInteractive) { clearConsole(); }
-      console.log(chalk.red('NODE HOT RELOAD:'), ' Changes detected in ', chalk.yellow(path.relative(rootDir, file)));
-      timer.start();
+  watcher
+    .watch(path.join(__dirname, '..'), { ignored: ignoreRegexp })
+    .on('all', (event, file) => {
+      if (event === 'change') {
+        if (isInteractive) {
+          clearConsole();
+        }
+        console.log(
+          chalk.red('NODE HOT RELOAD:'),
+          ' Changes detected in ',
+          chalk.yellow(path.relative(rootDir, file))
+        );
+        timer.start();
 
-      // remember cache size
-      const originalCacheSize = Object.keys(require.cache).length;
+        // remember cache size
+        const originalCacheSize = Object.keys(require.cache).length;
 
-      // remove all files from require cache which are in ./src/ directory
-      // this will force next call of require to load files again
-      Object.keys(require.cache).forEach((id) => {
-        if (sourceFilesRegexp.test(id)) delete require.cache[id];
-      });
+        // remove all files from require cache which are in ./src/ directory
+        // this will force next call of require to load files again
+        Object.keys(require.cache).forEach(id => {
+          if (sourceFilesRegexp.test(id)) delete require.cache[id];
+        });
 
-      // enforce node to cache main.js directly after removing cache
-      // This speeds up development process - after change node is caching new changed content
-      // and user will get faster response
-      if (originalCacheSize !== Object.keys(require.cache).length) {
-        if (preloadApplication()) {
-          console.log(
-            `${chalk.green('NODE HOT RELOAD:')} Caching new version finished in ${chalk.green('%dms')} at %s`,
-            timer.get(),
-            new Date()
-          );
+        // enforce node to cache main.js directly after removing cache
+        // This speeds up development process - after change node is caching new changed content
+        // and user will get faster response
+        if (originalCacheSize !== Object.keys(require.cache).length) {
+          if (preloadApplication()) {
+            console.log(
+              `${chalk.green('NODE HOT RELOAD:')} Caching new version finished in ${chalk.green('%dms')} at %s`,
+              timer.get(),
+              new Date()
+            );
+          }
         }
       }
-    }
-  });
+    });
 };
 
 // Create express app
@@ -87,8 +97,9 @@ const WebpackIsomorphicTools = require('webpack-isomorphic-tools');
 const webpack = require('webpack');
 const config = require('../../webpack/webpack.config');
 
-global.webpackIsomorphicTools = new WebpackIsomorphicTools(webpackIsomorphicAssets)
-  .server(rootDir, () => console.log('Webpack isomorphic tools started.'));
+global.webpackIsomorphicTools = new WebpackIsomorphicTools(
+  webpackIsomorphicAssets
+).server(rootDir, () => console.log('Webpack isomorphic tools started.'));
 
 // Make express to listen on port
 const port = process.env.PORT || 8000;
@@ -116,20 +127,17 @@ if (process.env.NODE_ENV === 'development') {
   app.use(middleware);
   app.use(webpackHotMiddleware(compiler));
 
-  spdy
-    .createServer(options, app)
-    .listen(port, (error) => {
-      if (error) {
-        console.error(error);
-        return process.exit(1);
-      }
-      watchChanges();
-      return undefined;
-    });
+  spdy.createServer(options, app).listen(port, error => {
+    if (error) {
+      console.error(error);
+      return process.exit(1);
+    }
+    watchChanges();
+    return undefined;
+  });
 } else {
   app.listen(port);
 }
-
 
 // HOT RELOAD: We need to require('./main') in every call to express app
 // When application is required and in cache it will not slow it down
@@ -146,11 +154,12 @@ app.use((req, res, cb) => {
 
 // This is most simple error handler which will show error,
 // when there is some error in other error handlers
-app.use((err, req, res, next) => { // eslint-disable-line no-unused-vars
+// eslint-disable-next-line no-unused-vars
+app.use((err, req, res, next) => {
   console.error(chalk.red('Last resort error handler catched'), err.stack);
   res.status(500).send(`
     Last resort error handler caught error at path: ${req.path}
-    ${err.stack.toString().replace(/\[\d+m/mg, '')}
+    ${err.stack.toString().replace(/\[\d+m/gm, '')}
   `);
 });
 

--- a/src/server/main.js
+++ b/src/server/main.js
@@ -32,8 +32,16 @@ app.use(frontend);
 
 // Error reporter
 if (process.env.ROLLBAR_SERVER_TOKEN && process.env.APP_ENV !== 'development') {
-  console.log('Error reporting to rollbar with TOKEN %s and ENV %s', process.env.ROLLBAR_SERVER_TOKEN, process.env.APP_ENV);
-  app.use(rollbar.errorHandler(process.env.ROLLBAR_SERVER_TOKEN, { environment: process.env.APP_ENV }));
+  console.log(
+    'Error reporting to rollbar with TOKEN %s and ENV %s',
+    process.env.ROLLBAR_SERVER_TOKEN,
+    process.env.APP_ENV
+  );
+  app.use(
+    rollbar.errorHandler(process.env.ROLLBAR_SERVER_TOKEN, {
+      environment: process.env.APP_ENV
+    })
+  );
 }
 
 // Error handler

--- a/src/server/middlewares/errorHandler.js
+++ b/src/server/middlewares/errorHandler.js
@@ -2,18 +2,24 @@ import PrettyError from 'pretty-error';
 
 const prettyError = new PrettyError();
 
-export default function errorHandler(err, req, res, next) { // eslint-disable-line no-unused-vars
-  const stackOutput = prettyError.render(err, false, true)
-    .replace(/\[1m/mg, '<span style="color: red">')
-    .replace(/\[97m/mg, '<span style="color: red">')
-    .replace(/\[93m/mg, '<span style="color: blue">')
-    .replace(/\[39m/mg, '<span style="color: gray">')
-    .replace(/\[32m/mg, '<span style="color: green">')
-    .replace(/\[90m/mg, '<span style="color: darkgray">')
-    .replace(/\[33m/mg, '<span style="color: black">')
-    .replace(/\[\d+m/mg, '<span style="color: gray">')
-    .replace(/\[0m/mg, '</span>')
+// eslint-disable-next-line no-unused-vars
+export default function errorHandler(err, req, res, next) {
+  const stackOutput = prettyError
+    .render(err, false, true)
+    .replace(/\[1m/gm, '<span style="color: red">')
+    .replace(/\[97m/gm, '<span style="color: red">')
+    .replace(/\[93m/gm, '<span style="color: blue">')
+    .replace(/\[39m/gm, '<span style="color: gray">')
+    .replace(/\[32m/gm, '<span style="color: green">')
+    .replace(/\[90m/gm, '<span style="color: darkgray">')
+    .replace(/\[33m/gm, '<span style="color: black">')
+    .replace(/\[\d+m/gm, '<span style="color: gray">')
+    .replace(/\[0m/gm, '</span>')
     .replace(/\n/gm, '<br />');
 
-  return res.status(500).send(`<html></body><h1>Error at path: ${req.path}</h1><code><pre>${stackOutput}</pre></code></body></html>`);
+  return res
+    .status(500)
+    .send(
+      `<html></body><h1>Error at path: ${req.path}</h1><code><pre>${stackOutput}</pre></code></body></html>`
+    );
 }

--- a/src/utils/drawHaystack.js
+++ b/src/utils/drawHaystack.js
@@ -1,4 +1,4 @@
-export default function () {
+export default function() {
   console.log('');
   console.log('  _    _                 _             _');
   console.log(' | |  | |               | |           | |');

--- a/yarn.lock
+++ b/yarn.lock
@@ -90,6 +90,12 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
+ansi-styles@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.0.0.tgz#5404e93a544c4fec7f048262977bebfe3155e0c1"
+  dependencies:
+    color-convert "^1.0.0"
+
 ansicolors@~0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/ansicolors/-/ansicolors-0.2.1.tgz#be089599097b74a5c9c4a84a0cdbcdb62bd87aef"
@@ -197,6 +203,10 @@ assert@^1.1.1:
   dependencies:
     util "0.10.3"
 
+ast-types@0.9.8:
+  version "0.9.8"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.8.tgz#6cb6a40beba31f49f20928e28439fc14a3dab078"
+
 async-each@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
@@ -231,7 +241,7 @@ aws4@^1.2.1:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.5.0.tgz#0a29ffb79c31c9e712eeb087e8e7a64b4a56d755"
 
-babel-code-frame@^6.16.0, babel-code-frame@^6.22.0:
+babel-code-frame@6.22.0, babel-code-frame@^6.16.0, babel-code-frame@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.22.0.tgz#027620bee567a88c32561574e7fd0801d33118e4"
   dependencies:
@@ -960,6 +970,10 @@ babel-types@^6.15.0, babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.22
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
+babylon@7.0.0-beta.8:
+  version "7.0.0-beta.8"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.8.tgz#2bdc5ae366041442c27e068cce6f0d7c06ea9949"
+
 babylon@^6.11.0, babylon@^6.13.0, babylon@^6.15.0:
   version "6.15.0"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.15.0.tgz#ba65cfa1a80e1759b0e89fb562e27dccae70348e"
@@ -1291,6 +1305,16 @@ co@^4.6.0:
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
+
+color-convert@^1.0.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.0.tgz#1accf97dd739b983bf994d56fec8f95853641b7a"
+  dependencies:
+    color-name "^1.1.1"
+
+color-name@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.2.tgz#5c8ab72b64bd2215d617ae9559ebb148475cf98d"
 
 colors@1.0.3:
   version "1.0.3"
@@ -1910,6 +1934,13 @@ eslint-plugin-jsx-a11y@^3.0.2:
     jsx-ast-utils "^1.0.0"
     object-assign "^4.0.1"
 
+eslint-plugin-prettier@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.1.1.tgz#2fb7e2ab961f2b61d2c8cf91bc17716ca8c53868"
+  dependencies:
+    fast-diff "^1.1.1"
+    jest-docblock "^20.0.1"
+
 eslint-plugin-react@^6.9.0:
   version "6.9.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-6.9.0.tgz#54c2e9906b76f9d10142030bdc34e9d6840a0bb2"
@@ -1991,7 +2022,7 @@ estraverse@~4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.1.1.tgz#f6caca728933a850ef90661d0e17982ba47111a2"
 
-esutils@^2.0.0, esutils@^2.0.2:
+esutils@2.0.2, esutils@^2.0.0, esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
@@ -2092,6 +2123,10 @@ extglob@^0.3.1:
 extsprintf@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.0.2.tgz#e1080e0658e300b06294990cc70e1502235fd550"
+
+fast-diff@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.1.1.tgz#0aea0e4e605b6a2189f0e936d4b7fbaf1b7cfd9b"
 
 fast-levenshtein@~2.0.4:
   version "2.0.6"
@@ -2212,6 +2247,10 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
+flow-parser@0.45.0:
+  version "0.45.0"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.45.0.tgz#aa29d4ae27f06aa02817772bba0fcbefef7e62f0"
+
 for-in@^0.1.5:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-0.1.6.tgz#c9f96e89bfad18a545af5ec3ed352a1d9e5b4dc8"
@@ -2328,6 +2367,10 @@ get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
 
+get-stdin@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
+
 getpass@^0.1.1:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.6.tgz#283ffd9fc1256840875311c1b60e8c40187110e6"
@@ -2347,7 +2390,7 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5:
+glob@7.1.1, glob@^7.0.0, glob@^7.0.3, glob@^7.0.5:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
@@ -2984,6 +3027,10 @@ jest-diff@^18.1.0:
     jest-matcher-utils "^18.1.0"
     pretty-format "^18.1.0"
 
+jest-docblock@^20.0.1:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-20.0.3.tgz#17bea984342cc33d83c50fbe1545ea0efaa44712"
+
 jest-environment-jsdom@^18.1.0:
   version "18.1.0"
   resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-18.1.0.tgz#18b42f0c4ea2bae9f36cab3639b1e8f8c384e24e"
@@ -3029,6 +3076,13 @@ jest-matcher-utils@^18.1.0:
   dependencies:
     chalk "^1.1.3"
     pretty-format "^18.1.0"
+
+jest-matcher-utils@^19.0.0:
+  version "19.0.0"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-19.0.0.tgz#5ecd9b63565d2b001f61fbf7ec4c7f537964564d"
+  dependencies:
+    chalk "^1.1.3"
+    pretty-format "^19.0.0"
 
 jest-matchers@^18.1.0:
   version "18.1.0"
@@ -3100,6 +3154,15 @@ jest-util@^18.1.0:
     jest-file-exists "^17.0.0"
     jest-mock "^18.0.0"
     mkdirp "^0.5.1"
+
+jest-validate@19.0.0:
+  version "19.0.0"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-19.0.0.tgz#8c6318a20ecfeaba0ba5378bfbb8277abded4173"
+  dependencies:
+    chalk "^1.1.1"
+    jest-matcher-utils "^19.0.0"
+    leven "^2.0.0"
+    pretty-format "^19.0.0"
 
 jest@^18.1.0:
   version "18.1.0"
@@ -3237,6 +3300,10 @@ lcid@^1.0.0:
   resolved "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835"
   dependencies:
     invert-kv "^1.0.0"
+
+leven@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/leven/-/leven-2.1.0.tgz#c2e7a9f772094dee9d34202ae8acce4687875580"
 
 levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
@@ -3539,7 +3606,7 @@ minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@^1.1.1, minimist@^1.2.0:
+minimist@1.2.0, minimist@^1.1.1, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
@@ -3969,6 +4036,21 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
+prettier@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.3.1.tgz#fa0ea84b45ac0ba6de6a1e4cecdcff900d563151"
+  dependencies:
+    ast-types "0.9.8"
+    babel-code-frame "6.22.0"
+    babylon "7.0.0-beta.8"
+    chalk "1.1.3"
+    esutils "2.0.2"
+    flow-parser "0.45.0"
+    get-stdin "5.0.1"
+    glob "7.1.1"
+    jest-validate "19.0.0"
+    minimist "1.2.0"
+
 pretty-error@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/pretty-error/-/pretty-error-2.0.2.tgz#a7db19cbb529ca9f0af3d3a2f77d5caf8e5dec23"
@@ -3981,6 +4063,12 @@ pretty-format@^18.1.0:
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-18.1.0.tgz#fb65a86f7a7f9194963eee91865c1bcf1039e284"
   dependencies:
     ansi-styles "^2.2.1"
+
+pretty-format@^19.0.0:
+  version "19.0.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-19.0.0.tgz#56530d32acb98a3fa4851c4e2b9d37b420684c84"
+  dependencies:
+    ansi-styles "^3.0.0"
 
 private@^0.1.6:
   version "0.1.6"


### PR DESCRIPTION
Adds [prettier](https://github.com/prettier/prettier) as an _eslint_ rule, which applies opinionated and consistent code formatting, and removes the need to think about it, or start another unnecessary discussion about JS code style.

The formatting can be applied together with other _eslint_ rules by running e.g.: `./node_modules/.bin/eslint --fix src`.

The PR is made of two commits.
First sets up the rules, it was necessary to slightly soften the used _airbnb_ config, and overwrite _prettier_ default usage of double quotes (which IMHO isn't a reasonable default, also this project was using single quotes anyway).
Second consist of changes made after running mentioned `./node_modules/.bin/eslint --fix src`, and moving occurrences of `eslint-disable-line` into a line above, using `eslint-disable-next-line` instead.

All of the changes are made only for the _master_ branch so far.